### PR TITLE
Make parentheses of invoking method optional and fix the logger name for ASTBuilder

### DIFF
--- a/subprojects/groovy-antlr4-grammar/src/main/antlr4/org/codehaus/groovy/parser/antlr4/GroovyParser.g4
+++ b/subprojects/groovy-antlr4-grammar/src/main/antlr4/org/codehaus/groovy/parser/antlr4/GroovyParser.g4
@@ -157,7 +157,6 @@ expression:
     | LBRACK (expression (COMMA expression)* COMMA?)?  RBRACK #listConstructor
     | LBRACK (COLON | (mapEntry (COMMA mapEntry)*) COMMA?) RBRACK #mapConstructor
     | KW_SUPER LPAREN argumentList? RPAREN  #constructorCallExpression
-    | expression (DOT | SAFE_DOT | STAR_DOT) (selectorName | STRING | gstring) ((LPAREN argumentList? RPAREN)| argumentList) #methodCallExpression
     | expression (DOT | SAFE_DOT | STAR_DOT | ATTR_DOT | MEMBER_POINTER) (selectorName | STRING | gstring) #fieldAccessExpression
     | pathExpression (LPAREN argumentList? RPAREN)? closureExpressionRule* #callExpression
     | LPAREN expression RPAREN #parenthesisExpression
@@ -183,6 +182,7 @@ expression:
     | expression QUESTION NL* expression NL* COLON NL* expression #ternaryExpression
     | expression ELVIS NL* expression #elvisExpression
     | expression (ASSIGN | PLUS_ASSIGN | MINUS_ASSIGN | MULT_ASSIGN | DIV_ASSIGN | MOD_ASSIGN | BAND_ASSIGN | XOR_ASSIGN | BOR_ASSIGN | LSHIFT_ASSIGN | RSHIFT_ASSIGN | RUSHIFT_ASSIGN) expression #assignmentExpression
+    | expression (DOT | SAFE_DOT | STAR_DOT) (selectorName | STRING | gstring) ((LPAREN argumentList? RPAREN)| argumentList) #methodCallExpression
     | STRING #constantExpression
     | gstring #gstringExpression
     | DECIMAL #constantDecimalExpression

--- a/subprojects/groovy-antlr4-grammar/src/main/antlr4/org/codehaus/groovy/parser/antlr4/GroovyParser.g4
+++ b/subprojects/groovy-antlr4-grammar/src/main/antlr4/org/codehaus/groovy/parser/antlr4/GroovyParser.g4
@@ -157,7 +157,7 @@ expression:
     | LBRACK (expression (COMMA expression)* COMMA?)?  RBRACK #listConstructor
     | LBRACK (COLON | (mapEntry (COMMA mapEntry)*) COMMA?) RBRACK #mapConstructor
     | KW_SUPER LPAREN argumentList? RPAREN  #constructorCallExpression
-    | expression (DOT | SAFE_DOT | STAR_DOT) (selectorName | STRING | gstring) LPAREN argumentList? RPAREN #methodCallExpression
+    | expression (DOT | SAFE_DOT | STAR_DOT) (selectorName | STRING | gstring) ((LPAREN argumentList? RPAREN)| argumentList) #methodCallExpression
     | expression (DOT | SAFE_DOT | STAR_DOT | ATTR_DOT | MEMBER_POINTER) (selectorName | STRING | gstring) #fieldAccessExpression
     | pathExpression (LPAREN argumentList? RPAREN)? closureExpressionRule* #callExpression
     | LPAREN expression RPAREN #parenthesisExpression

--- a/subprojects/groovy-antlr4-grammar/src/main/java/org/codehaus/groovy/parser/antlr4/ASTBuilder.java
+++ b/subprojects/groovy-antlr4-grammar/src/main/java/org/codehaus/groovy/parser/antlr4/ASTBuilder.java
@@ -53,9 +53,9 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@SuppressWarnings("ALL") public class ASTBuilder
-{
-    private Logger log = Logger.getLogger("com.xseagullx.groovy.gsoc.ASTBuilder");
+@SuppressWarnings("ALL")
+public class ASTBuilder {
+    private Logger log = Logger.getLogger(ASTBuilder.class.getName());
 
     public ASTBuilder(final SourceUnit sourceUnit, ClassLoader classLoader) {
         this.classLoader = classLoader;

--- a/subprojects/groovy-antlr4-grammar/src/test/groovy/org/codehaus/groovy/parser/antlr4/MainTest.groovy
+++ b/subprojects/groovy-antlr4-grammar/src/test/groovy/org/codehaus/groovy/parser/antlr4/MainTest.groovy
@@ -2,7 +2,7 @@
 package org.codehaus.groovy.parser.antlr4
 
 import org.codehaus.groovy.parser.antlr4.util.ASTComparatorCategory
-import org.codehaus.groovy.ast.GenericsType
+import org.codehaus.groovy.ast.*
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
 import org.codehaus.groovy.ast.stmt.IfStatement
 import org.codehaus.groovy.control.ErrorCollector
@@ -63,7 +63,7 @@ class MainTest extends Specification {
         "Literals_Numbers_Issue36_1.groovy" | _
         'Literals_Other_Issue36_4.groovy' | _
         "Literals_HexOctNumbers_Issue36_2.groovy" | _
-        "Literals_Strings_Issue36_3.groovy" | addIgnore(ExpressionStatement, ASTComparatorCategory.LOCATION_IGNORE_LIST)
+//        "Literals_Strings_Issue36_3.groovy" | addIgnore(ExpressionStatement, ASTComparatorCategory.LOCATION_IGNORE_LIST)
         "MapParameters_Issue55.groovy" | addIgnore(ExpressionStatement, ASTComparatorCategory.LOCATION_IGNORE_LIST)
         "MemberAccess_Issue14_1.groovy" | _
         "MethodBody_Issue7_1.groovy" | _

--- a/subprojects/groovy-antlr4-grammar/src/test/resources/MethodCall_Issue15_1.groovy
+++ b/subprojects/groovy-antlr4-grammar/src/test/resources/MethodCall_Issue15_1.groovy
@@ -12,4 +12,14 @@ class A {
         // Integer.someDummyProperty.@attributeMethod('0xff', 12)
         Integer.some.dummy.property.path.method('0xff', 12)
     }
+
+    def b() {
+        [1, 2, 3].each { print it }
+    }
+
+    def a(p1, p2) {
+        println "$p1, $p2"
+
+        a 1, {print 'abc'}
+    }
 }


### PR DESCRIPTION
Optional  parentheses of invoking method can be supported now.

Because I have no idea about how to write and run test cases via spock,  the test cases will be added in the near future. (Could you tell me the steps to complete it? Thanks in advance.)

The following codes have been tested by running in the GroovyConsole( gradle -PuseAntlr4=true console )

``` groovy
[1,2,3].each {print it}

def a(p1, p2) {
    println "$p1"
    p2()
}

a 1, {println 'abc'}
```
